### PR TITLE
WIP: Provision cluster with OpenTofu

### DIFF
--- a/.github/workflows/opentofu.yaml
+++ b/.github/workflows/opentofu.yaml
@@ -1,0 +1,43 @@
+name: OpenTofu
+
+on:
+  push:
+    branches:
+    - main
+
+defaults:
+  run:
+    working-directory: infrastructure/equinix-metal
+
+jobs:
+  opentofu:
+    name: OpenTofu
+    runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      TF_VAR_equinix_auth_token: ${{ secrets.EQUINIX_AUTH_TOKEN }}
+      TF_VAR_project_id: ${{ secrets.PROJECT_ID }}
+      TF_VAR_ssh_public_key: ${{ secrets.SSH_PUBLIC_KEY }}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: opentofu/setup-opentofu@v1
+
+    - name: Add SSH key
+      run: |
+        mkdir -p ~/.ssh
+        echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+        chmod 600 ~/.ssh/id_rsa
+        ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+        ssh-add ~/.ssh/id_rsa
+      env:
+        SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+
+    - name: OpenTofu init
+      run: tofu init
+
+    - name: OpenTofu plan
+      run: tofu plan
+
+    - name: OpenTofu apply
+      run: tofu apply -auto-approve

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+infrastructure/equinix-metal/.terraform/
+infrastructure/equinix-metal/inventory.ini
+infrastructure/equinix-metal/terraform.tfvars

--- a/infrastructure/equinix-metal/.terraform.lock.hcl
+++ b/infrastructure/equinix-metal/.terraform.lock.hcl
@@ -1,0 +1,58 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/equinix/equinix" {
+  version     = "1.13.0"
+  constraints = "1.13.0"
+  hashes = [
+    "h1:zU3t1iVOBnRul6XBjvJRXxXDlThN1Is7fc1JsqUGs+U=",
+    "zh:3a0805f40f993918fd7f3095c5f56200e8fdf905ffb5b8a5a114877322156484",
+    "zh:4e17f2db89ffb7f5479915171cdab102d0580b35a5428f53e7b225faa6a60a9e",
+    "zh:595cfe2723315b9c651740f1ced6bf8552ee524915b8bb2f543f202f3dccb216",
+    "zh:6eecfa6fcafee92aee13781d7e9ddd5787895c67cb23834ba0b0f6fbff570612",
+    "zh:82c34da527a9dfe4e5c59cb4cdb6ff6bfae962164b7f28c3b65e16751db32817",
+    "zh:875abc8f118da3d821a4e5fa3c2b0e847a16bb8069e846dfa0775b540d85bcfc",
+    "zh:adb1dd54f0ad92f5f2ab3b37a47da720f50d5449be5ef320bcd57251157be651",
+    "zh:b634d578144f00392a2b16aef82fff718211d04d1d577487db342bc6dc2c0736",
+    "zh:bb157ebb598b296cf2aeb569367bb8a45540bbaf6cb1fcf072ebc818ce5c67ff",
+    "zh:d0bd36e448440a293a222436f894250522ae84c84fe58470666b96a1f6843369",
+    "zh:da60c8d32a365352b19043c7fbd14e70ecc3ed2f31932667b7687d5fc6d8b395",
+    "zh:dbc3cf957f08b69c97d72c2b34a7cd2a774d52b8eacb92cbdb20cf15a402ade8",
+    "zh:f8aa590ad30c823d0bbb0264616c9fa43f708c626b0082341c4f47fa59f8a3f0",
+    "zh:fec98b511c0b457b29dd18b968f445f7f28c7dc09b27eb9160d6b84fdb327498",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version = "2.4.0"
+  hashes = [
+    "h1:cZKMbwSvmjK4bgXY+1gSBd5nodgkhRnw90lYvB8j0hI=",
+    "zh:184d6ec1f0e77713b37f0d9cf943b1371f2aa2f44c2c5a618978e897ce3dccab",
+    "zh:2205a7955a4051c2c25e69646a60746d9416b73001491808ae5d10620f7b7ac1",
+    "zh:256ddc56457f725819dc6be62f2d0bb3b9fee40a61771317bb32353df5b5c1a0",
+    "zh:70146e603f540523f6fa2251dd52c225db5a92bda8c07fd198ed51ae2b50176b",
+    "zh:8c3f9fe12ab8843e25ff7edabc26e01df4a0e8db204e432600a4c77a95ec0535",
+    "zh:b003e421f643d14247d31dcb7f0f6470c46f772d0e15a175a555a525ce344bf2",
+    "zh:b4c8ad7c5696aeb2a52adf6047d1e01943fafa57dc123d5192542527406ffd72",
+    "zh:c3b6fbfa431f3c085621c74596ee63681a278fd433a4758f33c627e8936d5cb3",
+    "zh:d2e57b19295b326d84ca5f39b797849d901170d5509aa7558f2a6545c9ce72a9",
+    "zh:e2307421b0b380eb0e8fcee008e0af98ae30fccbfc9e9a1d24d952489e9b0df9",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/null" {
+  version = "3.2.1"
+  hashes = [
+    "h1:+JAon/4CyriC/c7c77NjJalKrKx6gwwQ7L7rVABWMtA=",
+    "zh:40335019c11e5bdb3780301da5197cbc756b4b5ac3d699c52583f1d34e963176",
+    "zh:42356e687656fc8ec1f230f786f830f344e64419552ec483e2bc79bd4b7cf1e8",
+    "zh:5ce03460813954cbebc9f9ad5befbe364d9dc67acb08869f67c1aa634fbf6d6c",
+    "zh:658ea3e3e7ecc964bdbd08ecde63f3d79f298bab9922b29a6526ba941a4d403a",
+    "zh:68c06703bc57f9c882bfedda6f3047775f0d367093d00efb040800c798b8a613",
+    "zh:80fd03335f793dc54302dd53da98c91fd94f182bcacf13457bed1a99ecffbc1a",
+    "zh:91a76f371815a130735c8fcb6196804d878aebcc67b4c3b73571d2063336ffd8",
+    "zh:c146fc0291b7f6284fe4d54ce6aaece6957e9acc93fc572dd505dfd8bcad3e6c",
+    "zh:c38c9a295cfae9fb6372523c34b9466cd439d5e2c909b56a788960d387c24320",
+    "zh:e25265d4e87821d18dc9653a0ce01978a1ae5d363bc01dd273454db1aa0309c7",
+  ]
+}

--- a/infrastructure/equinix-metal/ansible-playbooks/main-playbook.yml
+++ b/infrastructure/equinix-metal/ansible-playbooks/main-playbook.yml
@@ -1,0 +1,6 @@
+---
+# Main playbook run to provision cluster.
+# TODO Implement playbook
+- name: Empty Play
+  hosts: all
+  tasks: []

--- a/infrastructure/equinix-metal/ansible.cfg
+++ b/infrastructure/equinix-metal/ansible.cfg
@@ -1,0 +1,7 @@
+[defaults]
+inventory = inventory.ini
+host_key_checking = False
+become = False
+
+[ssh_connection]
+retries=10

--- a/infrastructure/equinix-metal/main.tf
+++ b/infrastructure/equinix-metal/main.tf
@@ -1,0 +1,61 @@
+terraform {
+  required_providers {
+    equinix = {
+      source  = "equinix/equinix"
+      version = "1.13.0"
+    }
+  }
+
+  backend "s3" {
+    bucket  = "green-reviews-state-bucket"
+    key     = "opentofu/terraform.tfstate"
+    region  = "eu-central-1"
+    encrypt = true
+  }
+}
+
+provider "equinix" {
+  auth_token = var.equinix_auth_token
+}
+
+resource "equinix_metal_project_ssh_key" "ssh_key" {
+  name       = var.cluster_name
+  project_id = var.project_id
+  public_key = var.ssh_public_key
+}
+
+resource "equinix_metal_device" "control_plane" {
+  hostname            = "${var.cluster_name}-control-plane"
+  plan                = var.device_plan
+  metro               = var.device_metro
+  operating_system    = var.device_os
+  billing_cycle       = var.billing_cycle
+  project_id          = var.project_id
+  depends_on          = [equinix_metal_project_ssh_key.ssh_key]
+  project_ssh_key_ids = [equinix_metal_project_ssh_key.ssh_key.id]
+}
+
+resource "local_file" "inventory" {
+  filename = "${path.module}/inventory.ini"
+
+  content = <<-EOF
+    [control_plane]
+    ${equinix_metal_device.control_plane.hostname} ansible_host=${equinix_metal_device.control_plane.access_public_ipv4} ansible_user=root
+  EOF
+
+  depends_on = [
+    equinix_metal_device.control_plane
+  ]
+}
+
+resource "null_resource" "ansible_playbook" {
+  triggers = {
+    always_run = "${timestamp()}"
+  }
+
+  depends_on = [local_file.inventory]
+
+  provisioner "local-exec" {
+    command = "ansible-playbook -i ${path.module}/inventory.ini ${path.module}/ansible-playbooks/main-playbook.yml"
+  }
+}

--- a/infrastructure/equinix-metal/variables.tf
+++ b/infrastructure/equinix-metal/variables.tf
@@ -1,0 +1,47 @@
+variable "billing_cycle" {
+  description = "Billing cycle for the Equinix Metal device"
+  type        = string
+  default     = "hourly"
+}
+
+variable "cluster_name" {
+  description = "Name of the cluster"
+  type        = string
+  default     = "green-reviews"
+}
+
+variable "device_metro" {
+  description = "Metro location for the Equinix Metal device"
+  type        = string
+  default     = "pa"
+}
+
+variable "device_os" {
+  description = "Operating system for the Equinix Metal device"
+  type        = string
+  default     = "ubuntu_22_04"
+}
+
+variable "device_plan" {
+  description = "Plan type for the Equinix Metal device"
+  type        = string
+  default     = "m3.small.x86"
+}
+
+variable "equinix_auth_token" {
+  description = "Authentication token for Equinix Metal"
+  type        = string
+  sensitive = true
+}
+
+variable "project_id" {
+  description = "Project ID for the Equinix Metal resources"
+  type        = string
+  sensitive = true
+}
+
+variable "ssh_public_key" {
+  description = "SSH public key for the Equinix Metal device"
+  type        = string
+  sensitive = true
+}


### PR DESCRIPTION
This is a spike to investigate whether we can provision the Equinix infra using OpenTofu and the Equinix provider and Ansible to provision Kubernetes using Kubeadm.

Right now it just creates a single control plane node. I'm planning on extending it to create worker nodes but otherwise I'd like to wait to get feedback.

These secrets need to be added to the repo.

- `AWS_ACCESS_KEY_ID` for S3 bucket to store state
- `AWS_SECRET_ACCESS_KEY`
- `EQUINIX_AUTH_TOKEN `the Equinix project API key
- `PROJECT_ID` the Equinix project ID
- `SSH_PUBLIC_KEY` added as an Equinix project SSH key for Ansible
- `SSH_PRIVATE_KEY`

Example GitHub Actions [run](https://github.com/rossf7/green-reviews-tooling/actions/runs/6756211722/job/18365457579).